### PR TITLE
Update create_authorizationpolicyrule.yaml

### DIFF
--- a/create_authorizationpolicyrule.yaml
+++ b/create_authorizationpolicyrule.yaml
@@ -47,7 +47,7 @@
             dictionaryName: IdentityGroup
             attributeName: Name
             operator: equals
-            attributeValue: Employee
+            attributeValue: User Identity Groups:Employee
           name: User_VLAN_Access_Rule  # name our authz policy appropriately
         profile:
           - User_VLAN_Access  # assign the User_VLAN_Access authz profile


### PR DESCRIPTION
The RHS for an IdentityGroup condition needs qualified as
User Identity Groups:Employee

Please merge my change.

Thanks,
Hsing-Tsu